### PR TITLE
change backlog to 2

### DIFF
--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -1291,7 +1291,7 @@ void AsyncServer::begin(){
         return;
     }
 
-    static uint8_t backlog = 5;
+    static uint8_t backlog = 2;
     _pcb = _tcp_listen_with_backlog(_pcb, backlog);
     if (!_pcb) {
         log_e("listen_pcb == NULL");


### PR DESCRIPTION
Makes trying to load a website with multiple connections slower but more stable in my tests (with 5 every other try some connections fail and files aren't getting loaded)